### PR TITLE
Fix/correct user_sessionidx spelling and lowered blended_user_id 

### DIFF
--- a/macros/base/heap_users.sql
+++ b/macros/base/heap_users.sql
@@ -15,10 +15,10 @@
 
 select distinct
 
-    user_id,
-    last_value(
+    lower(user_id),
+    lower(last_value(
         {{heap.identity_field()}}
-        ) over ( {{window_clause}} ) as user_identity,
+                ) over ( {{window_clause}} )) as user_identity,
     last_value(lower(email)) over ( {{window_clause}} ) as email,
     min(joindate) over ( {{window_clause}} ) as joindate
     

--- a/macros/base/heap_users.sql
+++ b/macros/base/heap_users.sql
@@ -15,7 +15,7 @@
 
 select distinct
 
-    lower(user_id),
+    lower(user_id) as user_id,
     lower(last_value(
         {{heap.identity_field()}}
                 ) over ( {{window_clause}} )) as user_identity,

--- a/models/transform/heap_sessions_xf.sql
+++ b/models/transform/heap_sessions_xf.sql
@@ -63,12 +63,12 @@ with sessions as (
     
       s.*,
       row_number() over (partition by s.user_id order by s.session_start_time) 
-        as user_sesionidx,
+        as user_sessionidx,
       ea.session_end_time,
       ea.event_count,
       referrers.medium as referrer_medium,
       referrers.source as referrer_source,
-      coalesce(users.user_identity, s.user_id::varchar) as blended_user_id,
+      lower(coalesce(users.user_identity, s.user_id::varchar)) as blended_user_id,
       {{ dbt_utils.get_url_parameter('ea.first_page_query', 'gclid') }} as gclid
       
     from referring_domains s

--- a/models/transform/heap_sessions_xf.sql
+++ b/models/transform/heap_sessions_xf.sql
@@ -68,7 +68,7 @@ with sessions as (
       ea.event_count,
       referrers.medium as referrer_medium,
       referrers.source as referrer_source,
-      lower(coalesce(users.user_identity, s.user_id::varchar)) as blended_user_id,
+      coalesce(users.user_identity, s.user_id::varchar) as blended_user_id,
       {{ dbt_utils.get_url_parameter('ea.first_page_query', 'gclid') }} as gclid
       
     from referring_domains s


### PR DESCRIPTION
-Updated the spelling of the column user_sessionidx so it's correct.
-Inserted a lower command at the creation of blended_user_id since it often is based on email and joined to production data. This is a simple way to be consistent. 

The changes have been tested against the true botanicals repo locally and both the run and test were successful. 