### PR TITLE
Added additional fields to unique test for events table

### DIFF
--- a/models/base/schema.yml
+++ b/models/base/schema.yml
@@ -4,7 +4,7 @@ models:
   - name: heap_events
     
     columns:
-        - name: event_id
+        - name: event_id || session_id || user_id || event_table_name
           tests:
               - unique
               - not_null


### PR DESCRIPTION
event_id is not the primary key for this table (at least not in my case). Event_id, session_id, user_id, and event_table_name form the composite primary key for this table (which is actually a view). I have reached out to heap to confirm this.