### PR TITLE
fix/update csv column names to uppercase

### DIFF
--- a/data/referrer_mapping.csv
+++ b/data/referrer_mapping.csv
@@ -1,4 +1,4 @@
-medium,source,domain
+MEDIUM,SOURCE,DOMAIN
 email,Outlook.com,mail.live.com
 email,Orange Webmail,orange.fr/webmail
 email,Optus Zoo,webmail.optuszoo.com.au


### PR DESCRIPTION
With the update to dbt 0.15.0, column names in seed files in Snowflake are no longer being uppercased.  This is causing an identification error on Snowflake. 

This is a simple fix to capitalize `referrer_mapping` cvs file.  