### PR TITLE
Fix/update field name quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # heap
 Open source analytics for Heap SQL
 
-Requires dbt >= 0.12.2
+Requires dbt >= 0.15.0
 
 ## Installation
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,6 +8,8 @@ clean-targets: ["target, dbt_modules"]  # directories removed by the clean task
 test-paths: ["test"]       # where to store test results
 data-paths: ["data"]       # load CSVs from this directory with `dbt seed`
 
+require-dbt-version: "dbt >= 0.15.0"
+
 models:
   heap:
     vars:

--- a/models/transform/heap_sessions_xf.sql
+++ b/models/transform/heap_sessions_xf.sql
@@ -66,8 +66,8 @@ with sessions as (
         as user_sessionidx,
       ea.session_end_time,
       ea.event_count,
-      referrers.medium as referrer_medium,
-      referrers.source as referrer_source,
+      referrers.{{ adapter.quote('medium') }} as medium,
+      referrers.{{ adapter.quote('source') }} as referrer_source,
       coalesce(users.user_identity, s.user_id::varchar) as blended_user_id,
       {{ dbt_utils.get_url_parameter('ea.first_page_query', 'gclid') }} as gclid
       


### PR DESCRIPTION
With the update to dbt 0.15.0, column names in seed files in Snowflake are no longer being uppercased. This is causing an identification error on Snowflake.

This is a fix to put quotes around the fields so they are being referenced appropriately. 